### PR TITLE
align package version with published release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.5.2",
+  "version": "1.6.0",
   "license": "MIT",
   "main": "dist/index.js",
   "unpkg": "dist/vault-js.umd.production.min.js",


### PR DESCRIPTION
Fix: Tagged version was no longer aligned with published version. 